### PR TITLE
Hazelcast Jet - minor improvements

### DIFF
--- a/airquality/pom.xml
+++ b/airquality/pom.xml
@@ -246,7 +246,7 @@
 		<dependency>
 			<groupId>com.hazelcast.jet</groupId>
 			<artifactId>hazelcast-jet</artifactId>
-			<version>3.1</version>
+			<version>3.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Hello Martin,

thank you for playing with Jet. I am sending minor improvements:
1. Use local/test source as input
2. Count the polluted regions inside Jet

Reasoning:
Jet can use various sources: TestSources is good for exploring/learning. You can use
IMDG IList too, but I don't see a good reason in this case. 

There are sources for e.g. Apache Kafka, JMS, JDBC, HDFS, Redis and many other systems.
The same goes for Sinks: You can use IMDG, but also other systems.

In Jet 4.0 is going to be a support for a local collector - that will eliminate the IList even on the Sink side. 

Once more thank you for trying Jet and if you have any question, my [DM are open](https://twitter.com/jerrinot)